### PR TITLE
Improve instance_name take from Name tag

### DIFF
--- a/ec2inst/ec2inst.py
+++ b/ec2inst/ec2inst.py
@@ -28,6 +28,9 @@ def make_instance_list(response, columns):
 
         if "Tags" in instance.keys():
             instance_name = instance["Tags"][0]["Value"]
+            for tag in instance["Tags"]:
+                if tag["Key"] == "Name":
+                    instance_name = tag["Value"]
         else:
             instance_name = "-"
         instance_id = instance["InstanceId"]


### PR DESCRIPTION
# Summary
The instance_name use Name tag.

# Example
```bash
aws ec2 create-tags --resources i-xxx --tags Key=Name,Value=Server1 Key=Role,Value=App
```

tag|value
---|---
Name|Server1
Role|App

```bash
$ ec2inst -c instance_name
instance_name
---------------
App
```

I expect below

```bash
instance_name
---------------
Server1
```

P.S. Great tool. thanks. 😄 